### PR TITLE
Allow ability to change chrome driver version (default to 2.32)

### DIFF
--- a/lib/chromedriver/helper/google_code_parser.rb
+++ b/lib/chromedriver/helper/google_code_parser.rb
@@ -26,7 +26,7 @@ module Chromedriver
       end
 
       def penultimate_download
-        latest_downloads.detect { |chrome_url| chrome_url.include?('2.29') }
+        latest_downloads.detect { |chrome_url| chrome_url.include?(penultimate_version) }
       end
 
       def newest_download
@@ -34,6 +34,10 @@ module Chromedriver
       end
 
       private
+
+      def penultimate_version
+        ENV['CHROME_DRIVER_VERSION'] || '2.32'
+      end
 
       def version_of url
         Gem::Version.new grab_version_string_from(url)


### PR DESCRIPTION
There were a couple of failing tests related to elements being unclickable. Changing from version 2.29 to 2.32 (per [this comment](https://github.com/SeleniumHQ/docker-selenium/issues/566#issuecomment-329697590)) fixes the issues when running tests locally on the Prism `develop` branch. For example, running the test file `spec/requests/portal/rules_portal_spec.rb` failed without the update.

Example usage:

```bash
$ chromedriver -v
ChromeDriver 2.29.461585 (0be2cd95f834e9ee7c46bcc7cf405b483f5ae83b)

$ CHROME_DRIVER_VERSION=2.32 chromedriver-update

$ chromedriver -v
ChromeDriver 2.32.498537 (cb2f855cbc7b82e20387eaf9a43f6b99b6105061)
```

We should also be able to configure Solano with the appropriate version moving forward.